### PR TITLE
Fix tag style typo and README mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # My Personal Website
 
-This project is my personal website, hosted on GitHub Pages and build it with [Astro](https://astro.build) and accessible on [netoun.com](https://netoun.com).
+This project is my personal website, hosted on GitHub Pages and built with [Astro](https://astro.build) and accessible on [netoun.com](https://netoun.com).
 
 ## Stacks Used
 
 This project utilizes the following tools:
 
 - **[Astro](https://astro.build)** - A new kind of static site generator.
-- **[Tailwind CSS](https://tailwindcss.com)** - A sutility-first CSS framework.
+- **[Tailwind CSS](https://tailwindcss.com)** - A utility-first CSS framework.
 
 ## Miscellaneous
 

--- a/src/components/ui/tag.astro
+++ b/src/components/ui/tag.astro
@@ -112,7 +112,7 @@ const tagColors = {
   },
   "mikro-orm": {
     trad: "MikroOrm",
-    style: "--tag-mikro-orm)/k)]"
+    style: "--tag-mikro-orm"
   },
   "computer-science": {
     trad: "Computer Science",


### PR DESCRIPTION
## Summary
- fix typo in MikroOrm tag style so CSS variable works
- correct README grammar and fix Tailwind CSS description

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.15.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_683fff48f6048328a4a50862a05bd487