### PR TITLE
Fix print background

### DIFF
--- a/src/features/resume/resume-page.astro
+++ b/src/features/resume/resume-page.astro
@@ -230,7 +230,7 @@ type School = CollectionEntry<"school">
           <div class='space-y-8 print:space-y-4'>
             <div
               id='skills'
-              class='card bg-foreground/5 print:border-primary/50 relative overflow-hidden rounded-xl border p-6 shadow-xl print:border-none print:p-0 print:shadow-none'
+              class='card bg-foreground/5 print:bg-transparent print:border-primary/50 relative overflow-hidden rounded-xl border p-6 shadow-xl print:border-none print:p-0 print:shadow-none'
             >
               <div class='card-gradient absolute inset-0 opacity-0'></div>
               <div class='relative z-10'>
@@ -279,7 +279,7 @@ type School = CollectionEntry<"school">
             </div>
             <div
               id='miscellaneous'
-              class='card bg-foreground/5 print:border-primary/50 relative overflow-hidden rounded-xl border p-6 shadow-xl print:border-none print:p-0 print:shadow-none'
+              class='card bg-foreground/5 print:bg-transparent print:border-primary/50 relative overflow-hidden rounded-xl border p-6 shadow-xl print:border-none print:p-0 print:shadow-none'
             >
               <div class='card-gradient absolute inset-0 opacity-0'></div>
               <div class='relative z-10'>


### PR DESCRIPTION
## Summary
- remove gray background from Skills and Hobbies cards when printing

## Testing
- `npm run lint` *(fails: cannot find module 'prettier-config-standard')*
- `npm run typecheck` *(fails: TS2688: cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68400129d0248328b9116924be61e4c3